### PR TITLE
change scope of `currentPosition`

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ module.exports = (robot) => {
         per_page: 100
       })
 
-      let currentPosition = 0
       for (const file of files.data) {
+        let currentPosition = 0
         if (!file.filename.endsWith('.js')) return
 
         // In order to not spam the PR with comments we'll stop after a certain number of comments


### PR DESCRIPTION
- `currentPosition` is now re-indexed to 0 for each iteration in `file of files.data`.
- Previously, `currentPosition` was not scoped to each file, resulting in validation errors from the GH API if the value exceeded a file's length.