### PR TITLE
guard against files without a patch

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ module.exports = (robot) => {
         // In order to not spam the PR with comments we'll stop after a certain number of comments
         if (comments.length > commentLimit) return
 
+        // Bail if file does not contain valid patch (e.g., file was renamed)
+        if (!file.patch || typeof file.patch !== 'string') return
+
         const lines = file.patch.split('\n')
         for (const line of lines) {
           if (line.startsWith('+') && line.includes('eslint-disable')) {


### PR DESCRIPTION
Addresses case where the file object does not have a `patch` property (e.g., renames)

```json
[{
  "sha": ":file_sha1",
  "filename": "path/to/file.new.js",
  "status": "renamed",
  "additions": 0,
  "deletions": 0,
  "changes": 0,
  "blob_url": "https://github.com/:owner/:repo/blob/:ref_sha1/path/to/file.new.js",
  "raw_url": "https://github.com/:owner/:repo/raw/:ref_sha1/path/to/file.new.js",
  "contents_url": "https://api.github.com/repos/:owner/:repo/contents/path/to/file.new.js?ref=:ref_sha1",
  "previous_filename": "path/to/file.old.js"
}]
```